### PR TITLE
Fixed AM/PM time without "AM/PM" sign to 24H format

### DIFF
--- a/lib/editview/format.js
+++ b/lib/editview/format.js
@@ -15,7 +15,7 @@ exports.value = function (column, value) {
         case column.control.datetime:
             if (!value) return null;
             if (moment(value).isValid())
-                return moment(value).format('YYYY-MM-DD hh:mm:ss');
+                return moment(value).format('YYYY-MM-DD HH:mm:ss');
             return value;
 
         case column.control.binary:

--- a/lib/editview/validate.js
+++ b/lib/editview/validate.js
@@ -28,7 +28,7 @@ function format (column, value) {
 
         case column.control.datetime:
             if (!value || !moment(value).isValid()) return value;
-            return moment(value).format('YYYY-MM-DD hh:mm:ss');
+            return moment(value).format('YYYY-MM-DD HH:mm:ss');
 
         case column.control.radio:
             if (value === true) return 't';

--- a/lib/listview/format.js
+++ b/lib/listview/format.js
@@ -4,7 +4,7 @@ var moment = require('moment');
 
 exports.value = function (column, value) {
     if (/^(datetime|timestamp).*/i.test(column.type)) {
-        return value ? moment(value).format('ddd MMM DD YYYY hh:mm:ss') : '';
+        return value ? moment(value).format('ddd MMM DD YYYY HH:mm:ss') : '';
     }
     else if (/^date.*/i.test(column.type)) {
         return value ? moment(value).format('ddd MMM DD YYYY') : '';


### PR DESCRIPTION
Here is an issue: you use AM/PM 12H format for date but AM/PM is not displayed. Moreover, if you open any entity to edit, datetime field will be filled with time without AM/PM in 12H format, so after save if it's PM it will flush to AM. Here's a small fix: just moved to 24H format.
