### PR TITLE
Fixes static files path resolution.

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,7 +16,8 @@ var express = require('express'),
     methodOverride = require('method-override'),
     serveStatic = require('serve-static'),
     consolidate = require('consolidate'),
-    hogan = require('hogan.js');
+    hogan = require('hogan.js'),
+    getInstalledPath = require('get-installed-path');
 
 var moment = require('moment'),
     async = require('async');
@@ -206,7 +207,7 @@ function initServer (args) {
 
         .use(methodOverride())
         .use(serveStatic(path.join(__dirname, 'public')))
-        .use(serveStatic(path.join(__dirname, 'node_modules/express-admin-static')));
+        .use(serveStatic(getInstalledPath('express-admin-static', true)));
 
     if (!args.debug) app.set('view cache', true);
 

--- a/package.json
+++ b/package.json
@@ -1,60 +1,61 @@
 {
-    "name": "express-admin",
-    "version": "1.2.7",
-    "description": "MySql, MariaDB, SQLite and PostgreSQL database admin built with Express and Bootstrap.",
-    "keywords": [
-        "mysql",
-        "mariadb",
-        "sqlite",
-        "postgresql",
-        "database",
-        "admin",
-        "express",
-        "bootstrap"
-    ],
-    "license"   : "MIT",
-    "homepage"  : "https://github.com/simov/express-admin",
-    "author": "Simeon Velichkov <simeonvelichkov@gmail.com> (http://simov.github.io)",
-    "repository": {
-        "type"  : "git",
-        "url"   : "https://github.com/simov/grant.git"
-    },
-    "dependencies": {
-        "express"          : "4.4.4",
-        "morgan"           : "1.1.1",
-        "body-parser"      : "1.4.3",
-        "connect-multiparty": "1.1.0",
-        "cookie-parser"    : "1.3.1",
-        "express-session"  : "1.5.1",
-        "csurf"            : "1.2.2",
-        "method-override"  : "2.0.2",
-        "serve-static"     : "1.2.3",
-        "consolidate"      : "0.9.1",
-        "hogan.js"         : "3.0.2",
-        "mysql"            : "2.2.0",
-        "mysql-validator"  : "0.1.6",
-        "async"            : "0.9.0",
-        "pwd"              : "0.0.3",
-        "commander"        : "1.3.2",
-        "colors"           : "0.6.1",
-        "slugify"          : "0.1.0",
-        "sr-pagination"    : "1.0.1",
-        "deep-copy"        : "1.0.0",
-        "xsql"             : "1.0.1",
-        "moment"           : "2.8.3",
-        "express-admin-static": "2.2.2"
-    },
-    "devDependencies": {
-        "mocha" : "1.20.1",
-        "should": "4.0.4",
-        "supertest": "*",
-        "recursive-fs": "*"
-    },
-    "main": "./app",
-    "bin": {
-        "admin": "./bin/admin"
-    },
-    "scripts": {
-        "test": "make test"
-    }
+  "name": "express-admin",
+  "version": "1.2.7",
+  "description": "MySql, MariaDB, SQLite and PostgreSQL database admin built with Express and Bootstrap.",
+  "keywords": [
+    "mysql",
+    "mariadb",
+    "sqlite",
+    "postgresql",
+    "database",
+    "admin",
+    "express",
+    "bootstrap"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/simov/express-admin",
+  "author": "Simeon Velichkov <simeonvelichkov@gmail.com> (http://simov.github.io)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/simov/grant.git"
+  },
+  "dependencies": {
+    "async": "0.9.0",
+    "body-parser": "1.4.3",
+    "colors": "0.6.1",
+    "commander": "1.3.2",
+    "connect-multiparty": "1.1.0",
+    "consolidate": "0.9.1",
+    "cookie-parser": "1.3.1",
+    "csurf": "1.2.2",
+    "deep-copy": "1.0.0",
+    "express": "4.4.4",
+    "express-admin-static": "2.2.2",
+    "express-session": "1.5.1",
+    "get-installed-path": "^1.0.2",
+    "hogan.js": "3.0.2",
+    "method-override": "2.0.2",
+    "moment": "2.8.3",
+    "morgan": "1.1.1",
+    "mysql": "2.2.0",
+    "mysql-validator": "0.1.6",
+    "pwd": "0.0.3",
+    "serve-static": "1.2.3",
+    "slugify": "0.1.0",
+    "sr-pagination": "1.0.1",
+    "xsql": "1.0.1"
+  },
+  "devDependencies": {
+    "mocha": "1.20.1",
+    "should": "4.0.4",
+    "supertest": "*",
+    "recursive-fs": "*"
+  },
+  "main": "./app",
+  "bin": {
+    "admin": "./bin/admin"
+  },
+  "scripts": {
+    "test": "make test"
+  }
 }


### PR DESCRIPTION
Hey — I noticed that when embedding express-admin with the code shown under the "embedding" section of the documentation, none of the static assets are found. They all redirect to `/admin/login`. That's because of this line of code in `express-admin/app.js`:

`.use(serveStatic(path.join(__dirname, 'node_modules/express-admin-static')));`

This is looking for static assets in `node_modules/express-admin/node_modules/express-admin-static.` But `express-admin-static` isn't there; it's installed in the same `node_modules` that contains `express-admin` itself. Since npm version 3, [npm installs sub-dependencies in a flat way](https://docs.npmjs.com/how-npm-works/npm3).

Here's my suggestion on how to fix this. In this PR, I use the npm package `get-installed-path` to locate the real path to `express-admin-static`.
