### PR TITLE
image displaying functionality, plus Chinese translation revision

### DIFF
--- a/config/lang/cn.json
+++ b/config/lang/cn.json
@@ -23,7 +23,7 @@
     "views"             : "Views",
     "others"            : "其它",
     
-    "select"            : "对",
+    "select"            : "选择",
     "to-change"         : "进行修改",
     "filter"            : "按条件过滤",
     "clear"             : "清除",
@@ -33,14 +33,14 @@
     "or"                : "或",
     "today"             : "今天",
 
-    "add-another"       : "载追加",
+    "add-another"       : "添加",
     "remove"            : "移除",
     "add"               : "增加",
     "change"            : "修改",
     "delete"            : "删除",
     "save"              : "保存",
-    "save-continue"     : "保存然后继续修改",
-    "save-add"          : "保存然后增加",
+    "save-continue"     : "保存并继续编辑本条",
+    "save-add"          : "保存并添加下一条",
 
     "success"           : "成功",
     "error"             : "错误",

--- a/lib/data/list.js
+++ b/lib/data/list.js
@@ -32,6 +32,7 @@ exports.get = function (args, done) {
                 var value = rows[i][columns[j].name];
                 value = format.list.value(columns[j], value);
                 if (columns[j].manyToMany && value) value = {mtm: value.split(',')}
+                if (columns[j].control.image && value) value = {file: {img: value}};
                 values.push(value);
             }
             records.push({pk: pk, values: values});

--- a/views/listview.html
+++ b/views/listview.html
@@ -42,8 +42,16 @@
         {{/pk}}
         {{#values}}
             <td>
-                {{^mtm}}{{.}}{{/mtm}}
-                {{#mtm}}<span class="label label-default">{{.}}</span>{{/mtm}}
+                {{^file}}
+                    {{^mtm}}{{.}}{{/mtm}}
+                    {{#mtm}}<span class="label label-default">{{.}}</span>{{/mtm}}
+                {{/file}}
+                {{#file}}
+                    {{#img}}
+                        {{^mtm}}<span type="image">{{img}}</span>{{/mtm}}
+                        {{#mtm}}<span type="image" class="label label-default">{{.}}</span>{{/mtm}}
+                    {{/img}}
+                {{/file}}
             </td>
         {{/values}}
         </tr>


### PR DESCRIPTION
This pull request contain 2 changes:

1. Image displaying functionality

[Issue] In 'express-admin-example', it is hard-coded in 'images.js' to force the 2nd column of listview to display as an image item. It does not display images in any other columns, and also it causes any text field in the 2nd column unable to display properly.

[Solution] I fixed it by adding an image wrapper in the template, so that any columns of images can be located in the DOM (which works together with my commit in 'express-admin-example').

2. I improved the Chinese translation a bit.